### PR TITLE
Fix UnboundLocalError due to bug in except clause

### DIFF
--- a/metric_writer.py
+++ b/metric_writer.py
@@ -14,7 +14,10 @@ SERVCE_CHECK_INTERVAL = 15  # seconds
 REPORT_INTERVAL = SERVCE_CHECK_INTERVAL * 40
 
 
-logging.basicConfig(encoding='utf-8', level=logging.INFO)
+logging.basicConfig(
+    encoding='utf-8',
+    level=logging.INFO,
+    format="%(asctime)s %(name)-20s %(levelname)-8s %(message)s")
 log = logging
 
 

--- a/metric_writer.py
+++ b/metric_writer.py
@@ -44,23 +44,28 @@ def process_redis_server(redis_server, redis_port, redis_namespace):
     while True:
         try:
             data = "\n".join(lines)
-            response = requests.post("http://%s:%d/write" % (config.INFLUX_SERVER, config.INFLUX_PORT),
-                                     params=params, data=data)
+            response = requests.post("http://%s:%d/write" %
+                                     (config.INFLUX_SERVER,
+                                      config.INFLUX_PORT),
+                                     params=params,
+                                     data=data)
             if response.status_code in (200, 204):
                 return len(lines)
             elif str(response.status_code)[0] == '4':
-                log.error("Cannot write metric due to 4xx error. %s" % response.text)
+                log.error("Cannot write metric due to 4xx error. "
+                          "%s" % response.text)
                 return 0
             else:
                 error = response.text
         except Exception as e:
             error = e
-        log.warning("Cannot write metric due to other error Retyring. %s" % error)
+        log.warning("Cannot write metric due to other error Retrying. "
+                    "%s" % error)
 
         if monotonic() > timeout_notification:
             timeout_notification += 3600
-            log.error("Unable to submit metrics for quite some time. Something is surely broken! "
-                      "Error: %s" % error)
+            log.error("Unable to submit metrics for quite some time. "
+                      "Something is surely broken! Error: %s" % error)
 
         sleep(30)
 


### PR DESCRIPTION
Target variable of except clause gets cleared after exiting the block, therefore we need to store in another variable. Also, rename r to response to avoid confusion in sentry dashboard.